### PR TITLE
Initialize weekly legal watch log

### DIFF
--- a/docs/weekly-legal-watch.md
+++ b/docs/weekly-legal-watch.md
@@ -1,6 +1,6 @@
 # Weekly legal and workforce scheduling watch
 
-This file is the concise repository log for the weekly Työvuorolista.fi legal and workforce-scheduling review. The automation checks primary Finnish sources (including Finlex, ministries, occupational safety authorities and courts), labour-market organisations, and Työvuorolista.fi's public product, help and blog content. A fuller report is delivered in Finnish; this log records only material findings and resulting actions. Updates are proposed every Monday through a pull request and are never merged automatically.
+This file is the concise repository log for the weekly tyovuorolista.fi legal and workforce-scheduling review. The automation checks primary Finnish sources (including Finlex, ministries, occupational safety authorities and courts), labour-market organisations, and tyovuorolista.fi's public product, help and blog content. A fuller report is delivered in Finnish; this log records only material findings and resulting actions. Updates are proposed every Monday through a pull request and are never merged automatically.
 
 ## 2026-08-03
 

--- a/docs/weekly-legal-watch.md
+++ b/docs/weekly-legal-watch.md
@@ -1,0 +1,15 @@
+# Weekly legal and workforce scheduling watch
+
+This file is the concise repository log for the weekly Työvuorolista.fi legal and workforce-scheduling review. The automation checks primary Finnish sources (including Finlex, ministries, occupational safety authorities and courts), labour-market organisations, and Työvuorolista.fi's public product, help and blog content. A fuller report is delivered in Finnish; this log records only material findings and resulting actions. Updates are proposed every Monday through a pull request and are never merged automatically.
+
+## 2026-08-03
+
+- No new binding working-time regulation or relevant court decision was published after the previous review.
+- The Chancellor of Justice requested clearer limits and safeguards for the proposed administrative fee covering missing work schedules and working-time or annual-leave records. Update the existing article, but do not build against the draft yet. [Statement](https://oikeuskansleri.fi/-/laiminlyontimaksun-lisaaminen-tyoaika-ja-vuosilomalainsaadantoon)
+- Clarify the scope of annual-leave guidance: the current 7.5-hour reduction and Monday–Saturday counting must not appear universal where collective agreements differ.
+
+## 2026-07-27
+
+- Commerce-sector pay rose by 2.5% on 1 August; logistics night-work allowance rules change on 1 October. Date-version the rules and test shifts crossing the effective date. [PAM guidance](https://www.pam.fi/wp-content/uploads/2025/03/Kaupan-palkankorotusohje-vuosille-2025-2028.pdf)
+- Labour Court case TT 2026:19 shows repeated scheduling errors can lead to sanctions. Re-run collective-agreement checks against actual hours, not only planned shifts. [Decision](https://www.tyotuomioistuin.fi/ratkaisut/ratkaisujen-arkisto/tt-202619/)
+- Continue tracking the proposed administrative fee for missing schedules and records; the consultation closes on 21 August 2026. [Ministry update](https://valtioneuvosto.fi/-/1410877/lausuntokierros-alkaa-tyonantajalle-laiminlyontimaksu-tyoaika-ja-vuosilomavelvollisuuksien-laiminlyonnista)


### PR DESCRIPTION
## What changed

- Added `docs/weekly-legal-watch.md` as a concise English log for the weekly legal and workforce-scheduling review.
- Documented the source scope and PR-only update process.
- Backfilled the 27 July and 3 August 2026 review summaries.

## Why

This keeps material developments found outside the codebase visible in the tyovuorolista.fi repository without duplicating the full Finnish weekly report.

## Validation

- The change is documentation-only.
- The branch changes only `docs/weekly-legal-watch.md`.
- Future automation runs are instructed to open a dated PR and never merge automatically.